### PR TITLE
Fix exit code

### DIFF
--- a/bin/electron-mocha
+++ b/bin/electron-mocha
@@ -11,6 +11,9 @@ which('electron', function (err, resolvedPath) {
 })
 
 function runElectron (resolvedPath) {
+  // Default exit code
+  var exitCode = 0;
+
   var args = process.argv.slice(2)
   args.unshift(path.resolve(path.join(__dirname, '../index.js')))
   var electron = spawn(resolvedPath, args, { stdio: ['inherit', 'inherit', 'pipe'] })
@@ -18,6 +21,19 @@ function runElectron (resolvedPath) {
     var str = data.toString('utf8')
     // it's Chromium, STFU
     if (str.match(/^\[\d+\:\d+/)) return
+
+    // Parse for EXITCODE
+    if (str.indexOf('EXITCODE:') === 0) {
+      // memorize for "later"
+      exitCode = parseInt(str.substr(9), 10)
+      return;
+    }
     process.stderr.write(data)
   })
+
+  // If electron has exited
+  electron.on('exit', function(){
+    // we exit with the correct code
+    process.exit(exitCode)
+  });
 }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ app.on('ready', function () {
 function exit (code) {
   fs.remove(browserDataPath, function (err) {
     if (err) console.error(err)
+    // This is used as a workaround
+    console.error("EXITCODE:"+code)
     // process.exit() does not work properly
     // app.quit() does not set code
     // bug in Electron, see issue: https://github.com/atom/electron/issues/1983

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mocha",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mocha tests in Electron.",
   "preferGlobal": true,
   "main": "index.js",


### PR DESCRIPTION
I implemented a workaround for #1 and therefor #2. Basically I am doing exactly what you described in #2
I am printing the exit code from electron and than parse it in the runner so I can fix the exit code in the parent process. 

I have no idea how to run tests for this so I did’t write one.

I noticed that you print the [stack trace](https://github.com/FWeinb/electron-mocha/blob/fix-exit-code/index.js#L16-L17) I think those where used in development but could now be removed, right? 