### PR TITLE
Fix socket errors

### DIFF
--- a/renderer/console.js
+++ b/renderer/console.js
@@ -11,6 +11,10 @@ console.dir = function () {
 }
 
 // if we don't do this, we get socket errors and our tests crash
-process.stdout.write = function (msg) {
-  remoteConsole.log.apply(remoteConsole, arguments)
-}
+Object.defineProperty(process, 'stdout', {
+  value: {
+    write: function (msg) {
+      remoteConsole.log.apply(remoteConsole, arguments)
+    }
+  }
+})

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -1,7 +1,7 @@
+require('./console')
 var ipc = require('ipc')
 var mocha = require('../mocha')
 
-require('./console')
 
 // consider hooking up to mocha
 /* window.onerror = function (message, filename, lineno, colno, err) {


### PR DESCRIPTION
In order for this to work for me with the `--render` option, I needed to change your approach to hijacking `stdout.write`. I'm not sure if this is an Electron versioning issue, but the following changes resolve the issue for me.