### PR TITLE
Prevent error 'Incorrect value for stdio stream: inherit' by using di…

### DIFF
--- a/bin/electron-mocha
+++ b/bin/electron-mocha
@@ -21,7 +21,7 @@ which('electron', function (err, resolvedPath) {
 function runElectron (resolvedPath) {
   var args = process.argv.slice(2)
   args.unshift(path.resolve(path.join(__dirname, '../index.js')))
-  var electron = spawn(resolvedPath, args, { stdio: ['inherit', 'inherit', 'pipe'] })
+  var electron = spawn(resolvedPath, args, { stdio: [process.stdin, process.stdout, 'pipe'] })
   electron.stderr.on('data', function (data) {
     var str = data.toString('utf8')
     // it's Chromium, STFU


### PR DESCRIPTION
…rect references to stdin and stdout

I seem to be running into this error, https://github.com/joyent/node/issues/4030. And these changes are equivalent and avoid the error. https://nodejs.org/api/child_process.html#child_process_options_stdio