### PR TITLE
Support `--compilers` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Usage: electron-mocha [options] [files]
     -t, --timeout <ms>     set test-case timeout in milliseconds [2000]
     -u, --ui <name>        specify user-interface (bdd|tdd|exports)
     --check-leaks          check for global variable leaks
+    --compilers            use the given module(s) to compile files
     --globals <names>      allow the given comma-delimited global [names]
     --inline-diffs         display actual/expected differences inline within each string
     --interfaces           display available interfaces

--- a/args.js
+++ b/args.js
@@ -20,13 +20,13 @@ function parse (argv) {
     .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
     .option('--check-leaks', 'check for global variable leaks')
+    .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
     .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
     .option('--inline-diffs', 'display actual/expected differences inline within each string')
     .option('--interfaces', 'display available interfaces')
     .option('--no-timeouts', 'disables timeouts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
-    .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
 
   program.on('globals', function (val) {
     globals = globals.concat(list(val))

--- a/args.js
+++ b/args.js
@@ -26,6 +26,7 @@ function parse (argv) {
     .option('--no-timeouts', 'disables timeouts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
 
   program.on('globals', function (val) {
     globals = globals.concat(list(val))

--- a/mocha.js
+++ b/mocha.js
@@ -32,6 +32,16 @@ function createFromArgs (args) {
     files = files.concat(utils.lookupFiles(arg, extensions, args.recursive))
   })
 
+  args.compilers.forEach(function (c) {
+    var compiler = c.split(':')
+    var ext = compiler[0]
+    var mod = compiler[1]
+
+    if (mod[0] === '.') mod = path.join(process.cwd(), mod)
+    require(mod)
+    extensions.push(ext)
+  })
+
   files = files.map(function (f) {
     return path.resolve(f)
   })

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -2,7 +2,6 @@ require('./console')
 var ipc = require('ipc')
 var mocha = require('../mocha')
 
-
 // consider hooking up to mocha
 /* window.onerror = function (message, filename, lineno, colno, err) {
   console.log(err.message)


### PR DESCRIPTION
In order to support mocha compilers, the CLI `--compilers` argument has been pulled to the `electron-mocha` front-end, which makes calls like ```electron-mocha --compilers js:babel/register test/example.js``` possible in case one has written tests in ES6 for example.