### PR TITLE
End electron with correct exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,6 @@ app.on('ready', function () {
 function exit (code) {
   fs.remove(browserDataPath, function (err) {
     if (err) console.error(err)
-    process.exit(code);
+    process.exit(code)
   })
 }

--- a/index.js
+++ b/index.js
@@ -41,9 +41,6 @@ app.on('ready', function () {
 function exit (code) {
   fs.remove(browserDataPath, function (err) {
     if (err) console.error(err)
-    // process.exit() does not work properly
-    // app.quit() does not set code
-    // bug in Electron, see issue: https://github.com/atom/electron/issues/1983
-    app.quit(code)
+    process.exit(code);
   })
 }


### PR DESCRIPTION
I just did some testing of `process.exit(1)` in various versions of electron:
```
0.33.0 ×
0.33.1 ×
0.33.2 ×
0.33.3 ×
0.33.4 ×
0.33.5 ×
0.33.6 ×
0.33.7 ✔
0.33.8 ✔
0.34.0 ✔
```
So basically this is working for electron >= 0.33.7
Should I include a test for the electron version to ensure that electron-mocha is only started with a working electron version? 