### PR TITLE
Support `-w, --watch` and `--watch-extensions` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage: electron-mocha [options] [files]
     -s, --slow <ms>        "slow" test threshold in milliseconds [75]
     -t, --timeout <ms>     set test-case timeout in milliseconds [2000]
     -u, --ui <name>        specify user-interface (bdd|tdd|exports)
+    -w, --watch            watch files for changes
     --check-leaks          check for global variable leaks
     --compilers            use the given module(s) to compile files
     --globals <names>      allow the given comma-delimited global [names]
@@ -64,6 +65,7 @@ Usage: electron-mocha [options] [files]
     --no-timeouts          disables timeouts
     --recursive            include sub directories
     --renderer             run tests in renderer process
+    --watch-extensions     additional extensions to monitor with --watch
 
 ```
 

--- a/args.js
+++ b/args.js
@@ -19,6 +19,7 @@ function parse (argv) {
     .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
     .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
+    .option('-w, --watch', 'watch files for changes')
     .option('--check-leaks', 'check for global variable leaks')
     .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
     .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
@@ -27,6 +28,7 @@ function parse (argv) {
     .option('--no-timeouts', 'disables timeouts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--watch-extensions <ext>,...', 'additional extensions to monitor with --watch')
 
   program.on('globals', function (val) {
     globals = globals.concat(list(val))

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -9,6 +9,7 @@ var mocha = require('../mocha')
 }*/
 
 // console.log(JSON.stringify(window.__args__, null, 2))
-mocha.run(window.__args__, function (failureCount) {
+var args = JSON.parse(JSON.stringify(window.__args__))
+mocha.run(args, function (failureCount) {
   ipc.send('mocha-done', failureCount)
 })


### PR DESCRIPTION
I often use `--watch` in mocha.

Maybe this feature can use another method to complete, but usually need to restart Electron (it is very slow).