### PR TITLE
Expose mocha to window in renderer context

### DIFF
--- a/renderer/run.js
+++ b/renderer/run.js
@@ -2,6 +2,9 @@ require('./console')
 var ipc = require('ipc')
 var mocha = require('../mocha')
 
+// Expose mocha
+window.mocha = require('mocha')
+
 // consider hooking up to mocha
 /* window.onerror = function (message, filename, lineno, colno, err) {
   console.log(err.message)

--- a/test/test3.js
+++ b/test/test3.js
@@ -1,0 +1,10 @@
+var assert = require('assert')
+var mocha = require('mocha')
+
+/* global describe it */
+
+describe('describe: test 3', function () {
+  it('it: test 3', function () {
+    assert.strictEqual(window.mocha, mocha)
+  })
+})


### PR DESCRIPTION
There are some libraries, such as [angular-mocks](https://github.com/angular/bower-angular-mocks) that rely on mocha exposing itself to `window` to detect a testing environment.

`angular-mocks` for example, has the following code which uses to determine if `angular.mocks.module` and `angular.mocks.inject` should be declared, which are essential testing utilities in angular:

```js
if (window.jasmine || window.mocha) { ... }
```

See https://github.com/angular/bower-angular-mocks/blob/master/angular-mocks.js#L2448

Currently, `electron-mocha` doesn't expose mocha to `window`, therefore libraries like `angular-mocks` fail to detect a testing environment and lack expected functionality.

[mocha](http://mochajs.org) exposes itself like this:

```js
window.mocha = mocha
```

See https://github.com/mochajs/mocha/blob/master/mocha.js#L12414

We replicate this behaviour here.