### PR TITLE
Add support for mocha.opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Usage: electron-mocha [options] [files]
     --inline-diffs         display actual/expected differences inline within each string
     --interfaces           display available interfaces
     --no-timeouts          disables timeouts
+    --opts <path>          specify opts path [test/mocha.opts]
     --recursive            include sub directories
     --renderer             run tests in renderer process
 

--- a/args.js
+++ b/args.js
@@ -25,6 +25,7 @@ function parse (argv) {
     .option('--inline-diffs', 'display actual/expected differences inline within each string')
     .option('--interfaces', 'display available interfaces')
     .option('--no-timeouts', 'disables timeouts')
+    .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var ipc = require('ipc')
 var path = require('path')
 var os = require('os')
 var window = require('electron-window')
+var getOptions = require('mocha/bin/options')
 var args = require('./args')
 var mocha = require('./mocha')
 
@@ -18,6 +19,10 @@ process.on('uncaughtException', function (err) {
   exit(1)
 })
 
+// load mocha.opts into process.argv
+getOptions()
+
+// parse args
 var opts = args.parse(process.argv)
 
 var browserDataPath = path.join(os.tmpdir(), 'electron-mocha-' + Date.now().toString())


### PR DESCRIPTION
This enables support for `mocha.opts` simply using the original mocha code.

Thanks for electron-mocha!