### PR TITLE
Fixed exit status on running command

### DIFF
--- a/bin/electron-mocha
+++ b/bin/electron-mocha
@@ -28,4 +28,5 @@ function runElectron (resolvedPath) {
     if (str.match(/^\[\d+\:\d+/)) return
     process.stderr.write(data)
   })
+  electron.on('exit', function(code){ process.exit(code) })
 }


### PR DESCRIPTION
```sh
$ electron-mocha ./tests # Some tests fail
$ echo $?
0
```

I found that `bin/electron-mocha` script didn't propagate exit status
properly.  I fixed it.