### PR TITLE
Require ipcRenderer instead of ipcMain in the rendered context 

### DIFF
--- a/renderer/run.js
+++ b/renderer/run.js
@@ -5,7 +5,7 @@ var ipc
 var electronV = process.versions['electron'].split('.')
 if (parseInt(electronV[1], 10) >= 35 && electronV[0] === '0') {
   var electron = require('electron')
-  ipc = electron.ipcMain
+  ipc = electron.ipcRenderer
 } else {
   ipc = require('ipc')
 }


### PR DESCRIPTION
The following pull request:

https://github.com/jprichardson/electron-mocha/pull/26

introduces a change to make use of electron's new `electron.ipcMain`
property.

However it throws the following error when being used in the renderer
context:

```js
Cannot read property `send` of undefined.
```

The issue is that we should be referring `electron.ipcRenderer` instead
of `electron.ipcMain`, since this code runs in the renderer context.