### PR TITLE
Update electron-window

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/jprichardson/electron-mocha#readme",
   "dependencies": {
     "commander": "^2.8.1",
-    "electron-window": "^0.5.0",
+    "electron-window": "^0.6.0",
     "fs-extra": "^0.22.1",
     "mocha": "2.2.5",
     "which": "^1.1.1"


### PR DESCRIPTION
This gets rid of the loadURL deprecation warning