### PR TITLE
Add -r/--require support for renderer tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ app.setPath('userData', browserDataPath)
 
 app.on('ready', function () {
   if (!opts.renderer) {
+    opts.require.forEach(function (mod) {
+      require(mod)
+    })
     mocha.run(opts, exit)
   } else {
     var win = window.createWindow({ height: 700, width: 1200, 'web-preferences': { 'web-security': false } })

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -22,7 +22,13 @@ window.onerror = function (message, filename, lineno, colno, err) {
   })
 }
 
-// console.log(JSON.stringify(window.__args__, null, 2))
-mocha.run(window.__args__, function (failureCount) {
+var opts = window.__args__
+// console.log(JSON.stringify(opts, null, 2))
+
+opts.require.forEach(function (mod) {
+  require(mod)
+})
+
+mocha.run(opts, function (failureCount) {
   ipc.send('mocha-done', failureCount)
 })


### PR DESCRIPTION
This PR makes the -r/--require options load in browser/renderer depending on the --renderer switch. Without this, it is not possible to use the option to load helpers, custom matchers etc. into the renderer using -r/--require.

Fix #13 