### PR TITLE
Forward to main process.stdout not console.log

### DIFF
--- a/renderer/console.js
+++ b/renderer/console.js
@@ -17,9 +17,5 @@ console.dir = function () {
 
 // if we don't do this, we get socket errors and our tests crash
 Object.defineProperty(process, 'stdout', {
-  value: {
-    write: function (msg) {
-      remoteConsole.log.apply(remoteConsole, arguments)
-    }
-  }
+  value: remote.process.stdout
 })


### PR DESCRIPTION
Console.log implicitly adds line breaks; see #39 

Note: On Linux writes to process.stdout are written to the terminal, but on OS X they are not so it is still necessary to use the remote module.