### PR TITLE
Generate index.html for renderer tests, and pass relative paths to sc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage: electron-mocha [options] [files]
     -s, --slow <ms>        "slow" test threshold in milliseconds [75]
     -t, --timeout <ms>     set test-case timeout in milliseconds [2000]
     -u, --ui <name>        specify user-interface (bdd|tdd|exports)
+    --scripts <path>       scripts to load in renderer tests
     --check-leaks          check for global variable leaks
     --compilers            use the given module(s) to compile files
     --globals <names>      allow the given comma-delimited global [names]

--- a/args.js
+++ b/args.js
@@ -23,6 +23,7 @@ function parse (argv) {
     .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
     .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
+    .option('--scripts <path>', 'scripts to load in renderer tests', list, [])
     .option('--check-leaks', 'check for global variable leaks')
     .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
     .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-<head>
-<script src="./index.js"></script>
-</head>
-<body>
-  <b>You won't see this since the window is never shown.</b>
-</body>
-</html>

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -1,1 +1,0 @@
-require('./run')


### PR DESCRIPTION
…ripts to load before test runs with --script CLI option

Generates the index.html used in renderer text instead of loading a static file, which allows effortless use of third party libraries or other (legacy) scripts that do not expose CommonJS modules and expect to attach to the global window object.

Usage is eg. `electron-mocha --renderer --scripts  <path 1>,<path 2>,<further paths...> ./tests`, which will generate a temporary index.html like
```html
<script><!-- contents of file at path 1 --></script>
<script><!-- contents of file at path 2 --></script>
<script><!-- and so on --></script>
<script><!-- setup script identical in functionality to previous content of renderer folder --></script>
```
Paths should be relative to the working directory from where electron-mocha is launched.

The order of the scripts files is the same as provided to electron-mocha, so if any files have internal dependencies these need to be in the order they would appear concatenated or as individual script tags on a html page.

Writes the generated `index.html` to a temp directory, which is required for the browser security policy to not disable writing to localStorge and possibly other APIs in included code.