### PR TITLE
Add arbitrary scripts to renderer html page with --scripts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Usage: electron-mocha [options] [files]
     --opts <path>          specify opts path [test/mocha.opts]
     --recursive            include sub directories
     --renderer             run tests in renderer process
+    --scripts <path>       scripts to load in renderer tests
 
 ```
 

--- a/args.js
+++ b/args.js
@@ -32,6 +32,7 @@ function parse (argv) {
     .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--scripts <path>', 'scripts to load in renderer tests', list, [])
 
   program.on('globals', function (val) {
     globals = globals.concat(list(val))

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -26,6 +26,14 @@ opts.require.forEach(function (mod) {
   require(mod)
 })
 
-mocha.run(opts, function (failureCount) {
-  ipc.send('mocha-done', failureCount)
+opts.scripts.forEach(function (path) {
+  var scriptElem = document.createElement('script')
+  scriptElem.setAttribute('src', process.cwd() + '/' + path)
+  document.head.appendChild(scriptElem)
+})
+
+document.addEventListener( "DOMContentLoaded", function() {
+  mocha.run(opts, function (failureCount) {
+    ipc.send('mocha-done', failureCount)
+  })
 })


### PR DESCRIPTION
This is a simplification of [a previous PR](https://github.com/jprichardson/electron-mocha/pull/45), based on suggestions in the discussion there.

Adds arbitrary browser scripts specified on the command line to the html page loaded by the renderer process for test runs. Essentially allows to use browser-only scripts (without CommonJS or UMD support) in test runs.  `mocha.run` is called only after all scripts have been loaded to ensure correct execution.

Usage is `electron-mocha --renderer --scripts <path 1>,<path 2>,<further paths...> ./tests`, paths should be relative to the working directory from where `electron-mocha` is launched.

The order of the scripts files is the same as provided to `electron-mocha`, so if any files have internal dependencies these need to be in the order they would appear concatenated or as individual script tags on a html page.