### PR TITLE
Add option to preload script tags

### DIFF
--- a/args.js
+++ b/args.js
@@ -7,7 +7,6 @@ var cwd = process.cwd()
 
 function parse (argv) {
   var globals = []
-  var requires = []
 
   program._name = 'electron-mocha'
   program
@@ -19,7 +18,7 @@ function parse (argv) {
     .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
     .option('-f, --fgrep <string>', 'only run tests containing <string>')
     .option('-i, --invert', 'inverts --grep and --fgrep matches')
-    .option('-r, --require <name>', 'require the given module')
+    .option('-r, --require <name>', 'require the given module', modules, [])
     .option('-s, --slow <ms>', '"slow" test threshold in milliseconds [75]')
     .option('-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000]')
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
@@ -32,6 +31,7 @@ function parse (argv) {
     .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--preload <name>', 'preload the given script in renderer', modules, [])
 
   program.on('globals', function (val) {
     globals = globals.concat(list(val))
@@ -39,17 +39,9 @@ function parse (argv) {
 
   module.paths.push(cwd, join(cwd, 'node_modules'))
 
-  program.on('require', function (mod) {
-    var abs = fs.existsSync(mod) || fs.existsSync(mod + '.js')
-    if (abs) mod = resolve(mod)
-    requires.push(mod)
-  })
-
   program.parse(process.argv)
   var argData = JSON.parse(JSON.stringify(program))
   argData.files = argData.args
-
-  argData.require = requires
 
   // delete unused
   ;['commands', 'options', '_execs', '_args', '_name', '_events', '_usage', '_version', '_eventsCount', 'args'].forEach(function (key) {
@@ -61,6 +53,13 @@ function parse (argv) {
 
 function list (str) {
   return str.split(/ *, */)
+}
+
+function modules (mod, memo) {
+  var abs = fs.existsSync(mod) || fs.existsSync(mod + '.js')
+  if (abs) mod = resolve(mod)
+  memo.push(mod)
+  return memo
 }
 
 module.exports = {

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -26,6 +26,15 @@ opts.require.forEach(function (mod) {
   require(mod)
 })
 
-mocha.run(opts, function (failureCount) {
-  ipc.send('mocha-done', failureCount)
+opts.preload.forEach(function (script) {
+  var tag = document.createElement('script')
+  tag.src = script
+  tag.async = false
+  document.head.appendChild(tag)
+})
+
+window.addEventListener('load', function () {
+  mocha.run(opts, function (failureCount) {
+    ipc.send('mocha-done', failureCount)
+  })
 })


### PR DESCRIPTION
See discussion at #45 

This essentially adds a `--preload` option which can be used like `--require` for non common js modules; those scripts will be loaded via extra script tags in the renderer.

Credit belongs to @orbitbot -- I just combined the resolving of preload/require to make it easier to maintain. (Tests to follow in separate PR)