### PR TITLE
Handle --compiler before --require options

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,6 @@ app.setPath('userData', browserDataPath)
 
 app.on('ready', function () {
   if (!opts.renderer) {
-    opts.require.forEach(function (mod) {
-      require(mod)
-    })
     mocha.run(opts, exit)
   } else {
     var prefs = { height: 700, width: 1200 }

--- a/mocha.js
+++ b/mocha.js
@@ -42,6 +42,10 @@ function createFromArgs (args) {
     extensions.push(ext)
   })
 
+  args.require.forEach(function (mod) {
+    require(mod)
+  })
+
   files = files.map(function (f) {
     return path.resolve(f)
   })

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -22,10 +22,6 @@ window.onerror = function (message, filename, lineno, colno, err) {
 var opts = window.__args__
 // console.log(JSON.stringify(opts, null, 2))
 
-opts.require.forEach(function (mod) {
-  require(mod)
-})
-
 opts.preload.forEach(function (script) {
   var tag = document.createElement('script')
   tag.src = script


### PR DESCRIPTION
Fix #57 

This moves handling the `--require` option into the mocha file, to make sure that `--compilers` have already been loaded. @jprichardson can you confirm that this is OK?