### PR TITLE
Fix exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,9 @@ app.on('ready', function () {
     win._loadURLWithArgs(indexPath, opts, function () {})
     // win.showURL(indexPath, opts)
     ipc.on('mocha-done', function (event, code) {
-      win.destroy()
       exit(code)
     })
     ipc.on('mocha-error', function (event, data) {
-      win.destroy()
       writeError(data)
       exit(1)
     })

--- a/index.js
+++ b/index.js
@@ -53,13 +53,25 @@ app.on('ready', function () {
     var indexPath = path.resolve(path.join(__dirname, './renderer/index.html'))
     // undocumented call in electron-window
     win._loadURLWithArgs(indexPath, opts, function () {})
+
+    var exitCode = 0
+    process.on('exit', function () {
+      // Destroying the window below will exit with a code of 0, but we want to
+      // exit with whatever code we got from mocha. So re-exit with the stored
+      // exit code.
+      process.exit(exitCode)
+    })
     // win.showURL(indexPath, opts)
     ipc.on('mocha-done', function (event, code) {
-      exit(code)
+      exitCode = code
+      win.destroy()
+      exit(exitCode)
     })
     ipc.on('mocha-error', function (event, data) {
+      exitCode = 1
+      win.destroy()
       writeError(data)
-      exit(1)
+      exit(exitCode)
     })
   }
 })


### PR DESCRIPTION
If we destroy the only window, Electron seems to quit with an exit code of 0, so mocha’s success/failure won’t be communicated properly.

We don’t really need to worry about destroying it anyways, since we’re about to exit.