### PR TITLE
Remove Electron 0.x API calls / checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,7 @@ var getOptions = require('mocha/bin/options')
 var args = require('./args')
 var mocha = require('./mocha')
 var util = require('util')
-var app
-var ipc
-var v = process.versions.electron.split('.').map(Number)
-try {
-  app = require('electron').app
-  ipc = require('electron').ipcMain
-} catch (e) {
-  app = require('app')
-  ipc = require('ipc')
-}
+var { app, ipcMain: ipc } = require('electron')
 
 // these were suppose to do something, but they don't
 // https://github.com/atom/electron/blob/master/docs/api/chrome-command-line-switches.md#--vlog_level
@@ -41,15 +32,11 @@ app.on('ready', function () {
   if (!opts.renderer) {
     mocha.run(opts, exit)
   } else {
-    var prefs = { height: 700, width: 1200 }
-
-    if (v[0] === 0 && v[1] < 37) {
-      prefs['web-preferences'] = { 'web-security': false }
-    } else {
-      prefs.webPreferences = { webSecurity: false }
-    }
-
-    var win = window.createWindow(prefs)
+    var win = window.createWindow({
+      height: 700,
+      width: 1200,
+      webPreferences: { webSecurity: false }
+    })
     var indexPath = path.resolve(path.join(__dirname, './renderer/index.html'))
     // undocumented call in electron-window
     win._loadURLWithArgs(indexPath, opts, function () {})

--- a/renderer/console.js
+++ b/renderer/console.js
@@ -1,9 +1,4 @@
-var remote
-try {
-  remote = require('electron').remote
-} catch (e) {
-  remote = require('remote')
-}
+var { remote } = require('electron')
 var remoteConsole = remote.require('console')
 
 // we have to do this so that mocha output doesn't look like shit

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -1,11 +1,6 @@
 require('./console')
 var mocha = require('../mocha')
-var ipc
-try {
-  ipc = require('electron').ipcRenderer
-} catch (e) {
-  ipc = require('ipc')
-}
+var { ipcRenderer: ipc } = require('electron')
 
 // Expose mocha
 window.mocha = require('mocha')


### PR DESCRIPTION
@jprichardson are we ready for this or would you prefer to wait? (We could update the major version to make sure no one on Electron 0.x pulls this in)