### PR TITLE
Add debugger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usage: electron-mocha [options] [files]
     -u, --ui <name>        specify user-interface (bdd|tdd|exports)
     --check-leaks          check for global variable leaks
     --compilers            use the given module(s) to compile files
-    --debug                enable Electron debugger on port [5858]
+    --debug                enable Electron debugger on port [5858]; for --renderer tests show window and dev-tools
     --debug-brk            like --debug but pauses the script on the first line
     --globals <names>      allow the given comma-delimited global [names]
     --inline-diffs         display actual/expected differences inline within each string
@@ -68,8 +68,6 @@ Usage: electron-mocha [options] [files]
     --opts <path>          specify opts path [test/mocha.opts]
     --recursive            include sub directories
     --renderer             run tests in renderer process
-    --renderer-debug       show window and dev-tools during renderer tests
-    --renderer-debug-brk   like --renderer-debug but pauses the script on first line inside renderer
     --preload <name>       preload the given script in renderer process
 
 ```
@@ -102,7 +100,7 @@ before_script:
 
 ###  Debugger Support
 
-Use the `--debug` or `--debug-brk` options to enable Electron's debugger. Additionally, using `--renderer-debug` will enable the built-in debugger during your renderer tests, i.e., use that option in combination with a `debugger` statement anywhere in your tests or code to start debugging. Likewise, the `--renderer-debug-brk` option will automatically break immediately before running your renderer tests.
+Use the `--debug` or `--debug-brk` options to enable Electron's debugger. When using `--renderer` this will open the test window and open the dev-tools: use that option in combination with a `debugger` statement anywhere in your tests or code to start debugging.
 
 Roadmap
 -------

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Usage: electron-mocha [options] [files]
     -u, --ui <name>        specify user-interface (bdd|tdd|exports)
     --check-leaks          check for global variable leaks
     --compilers            use the given module(s) to compile files
+    --debug                enable Electron debugger on port [5858]
+    --debug-brk            like --debug but pauses the script on the first line
     --globals <names>      allow the given comma-delimited global [names]
     --inline-diffs         display actual/expected differences inline within each string
     --interfaces           display available interfaces
@@ -66,6 +68,8 @@ Usage: electron-mocha [options] [files]
     --opts <path>          specify opts path [test/mocha.opts]
     --recursive            include sub directories
     --renderer             run tests in renderer process
+    --renderer-debug       show window and dev-tools during renderer tests
+    --renderer-debug-brk   like --renderer-debug but pauses the script on first line inside renderer
     --preload <name>       preload the given script in renderer process
 
 ```
@@ -95,6 +99,10 @@ Your `.travis.yml` will need two extra lines of configuration to run this headle
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
 ```
+
+###  Debugger Support
+
+Use the `--debug` or `--debug-brk` options to enable Electron's debugger. Additionally, using `--renderer-debug` will enable the built-in debugger during your renderer tests, i.e., use that option in combination with a `debugger` statement anywhere in your tests or code to start debugging. Likewise, the `--renderer-debug-brk` option will automatically break immediately before running your renderer tests.
 
 Roadmap
 -------

--- a/args.js
+++ b/args.js
@@ -23,6 +23,8 @@ function parse (argv) {
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
     .option('--check-leaks', 'check for global variable leaks')
     .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
+    .option('--debug', 'enable Electron debugger on port [5858]')
+    .option('--debug-brk', 'like --debug but pauses the script on the first line')
     .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
     .option('--inline-diffs', 'display actual/expected differences inline within each string')
     .option('--interfaces', 'display available interfaces')
@@ -30,6 +32,8 @@ function parse (argv) {
     .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--renderer-debug', 'show window and dev-tools during renderer tests')
+    .option('--renderer-debug-brk', 'like --renderer-debug but pauses the script on first line inside renderer')
     .option('--preload <name>', 'preload the given script in renderer process', modules, [])
 
   module.paths.push(cwd, join(cwd, 'node_modules'))
@@ -37,6 +41,10 @@ function parse (argv) {
   program.parse(argv)
   var argData = JSON.parse(JSON.stringify(program))
   argData.files = argData.args
+
+  if (argData.rendererDebugBrk) {
+    argData.rendererDebug = true
+  }
 
   // delete unused
   ;['commands', 'options', '_execs', '_args', '_name', '_events', '_usage', '_version', '_eventsCount', 'args'].forEach(function (key) {

--- a/args.js
+++ b/args.js
@@ -23,7 +23,7 @@ function parse (argv) {
     .option('-u, --ui <name>', 'specify user-interface (bdd|tdd|exports)', 'bdd')
     .option('--check-leaks', 'check for global variable leaks')
     .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files', list, [])
-    .option('--debug', 'enable Electron debugger on port [5858]')
+    .option('--debug', 'enable Electron debugger on port [5858]; for --renderer tests show window and dev-tools')
     .option('--debug-brk', 'like --debug but pauses the script on the first line')
     .option('--globals <names>', 'allow the given comma-delimited global [names]', list, [])
     .option('--inline-diffs', 'display actual/expected differences inline within each string')
@@ -32,8 +32,6 @@ function parse (argv) {
     .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
-    .option('--renderer-debug', 'show window and dev-tools during renderer tests')
-    .option('--renderer-debug-brk', 'like --renderer-debug but pauses the script on first line inside renderer')
     .option('--preload <name>', 'preload the given script in renderer process', modules, [])
 
   module.paths.push(cwd, join(cwd, 'node_modules'))
@@ -42,8 +40,8 @@ function parse (argv) {
   var argData = JSON.parse(JSON.stringify(program))
   argData.files = argData.args
 
-  if (argData.rendererDebugBrk) {
-    argData.rendererDebug = true
+  if (argData.debugBrk) {
+    argData.debug = true
   }
 
   // delete unused

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ app.on('ready', function () {
     })
 
     win.on('ready-to-show', () => {
-      if (opts.rendererDebug) {
+      if (opts.debug) {
         win.show()
         win.webContents.openDevTools()
         win.webContents.on('devtools-opened', () => {

--- a/index.js
+++ b/index.js
@@ -45,6 +45,22 @@ app.on('ready', function () {
       width: 1200,
       webPreferences: { webSecurity: false }
     })
+
+    win.on('ready-to-show', () => {
+      if (opts.rendererDebug) {
+        win.show()
+        win.webContents.openDevTools()
+        win.webContents.on('devtools-opened', () => {
+          // Debugger is not immediately ready!
+          setTimeout(() => {
+            win.webContents.send('mocha-start')
+          }, 250)
+        })
+      } else {
+        win.webContents.send('mocha-start')
+      }
+    })
+
     var indexPath = path.resolve(path.join(__dirname, './renderer/index.html'))
     // undocumented call in electron-window
     win._loadURLWithArgs(indexPath, opts, function () {})

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -4,6 +4,6 @@
 <script src="./index.js"></script>
 </head>
 <body>
-  <b>You won't see this since the window is never shown.</b>
+  <b>Electron-Mocha Renderer Tests</b>
 </body>
 </html>

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -24,7 +24,10 @@ opts.preload.forEach(function (script) {
   document.head.appendChild(tag)
 })
 
-window.addEventListener('load', function () {
+ipc.on('mocha-start', () => {
+  if (opts.rendererDebugBrk) {
+    debugger // eslint-disable-line no-debugger
+  }
   mocha.run(opts, function (failureCount) {
     ipc.send('mocha-done', failureCount)
   })

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -25,9 +25,6 @@ opts.preload.forEach(function (script) {
 })
 
 ipc.on('mocha-start', () => {
-  if (opts.rendererDebugBrk) {
-    debugger // eslint-disable-line no-debugger
-  }
   mocha.run(opts, function (failureCount) {
     ipc.send('mocha-done', failureCount)
   })


### PR DESCRIPTION
Somewhat related to #68 this adds debugger support.

By default, Electron sees our command line switches, so passing `--debug` or `--debug-brk` is actually handled by Electron. This PR adds both switches  to our options list to make sure that we don't halt because these options were passed (but we don't do anything with them).

#68 was asking for VS Code support -- this could probably be made to work using [the debugger protocol](http://electron.atom.io/docs/api/web-contents/#webcontentsdebugger) but we can't implement this kind of integration in electron-mocha.

Instead, this PR adds a way to debug renderer tests using the built-in debugger. When you run the tests with `--renderer-debug` we will show the test runner window and open the dev-tools; futhermore, in my testing I noticed that there is a slight delay until the debugger is ready, so we delay running the tests a little bit. That is to say, if you don't do anything else this option will run your tests as usually, but with a slight delay and the window will show up while the tests are running. But the cool thing is: if you add a `debugger` statement anywhere in your tests or in your code the debugger will break once it reaches that statement.

Additionally, this adds a `--renderer-debug-brk` which will break right in the renderer just before mocha will start.

@jprichardson what do you think? 