### PR TITLE
Exit after webContents destroyed event fires

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+build: off
+
+branches:
+  only:
+    - master
+
+skip_tags: true
+
+install:
+  - ps: Install-Product node LTS
+  - npm install npm
+  - .\node_modules\.bin\npm install
+
+test_script:
+  - node --version
+  - .\node_modules\.bin\npm --version
+  - .\node_modules\.bin\npm test

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ app.on('ready', () => {
     win._loadURLWithArgs(indexPath, opts, () => {})
     // win.showURL(indexPath, opts)
     ipc.on('mocha-done', (event, count) => {
-      win.on('closed', () => app.exit(count))
+      win.webContents.once('destroyed', () => app.exit(count))
       win.close()
     })
     ipc.on('mocha-error', (event, data) => {

--- a/test/renderer/indexed-db-test.js
+++ b/test/renderer/indexed-db-test.js
@@ -1,0 +1,10 @@
+var assert = require('assert')
+
+/* global describe it */
+
+describe('accessing indexedDB', () => {
+  it('does not fail when deleting the temp directory on exit', () => {
+    const db = window.indexedDB.open('TestDatabase', 3)
+    assert.ok(db != null)
+  })
+})


### PR DESCRIPTION
On Windows, tests that access `indexedDB` (and other things) will fail on exit with an `EBUSY` error when the temp directory is deleted.

This is because even though the `closed` event has fired on the `BrowserWindow`, its `webContents` may not have been deleted yet and could still be holding file locks.

This pull request switches the `app.exit` call to be done when the `'destroyed'` event on `win.webContents` fires.

```
Error: EBUSY: resource busy or locked, unlink 'C:\Users\appveyor\AppData\Local\Temp\1\electron-mocha-8Cl0bn\databases\Databases.db'
    at Error (native)
    at Object.fs.unlinkSync (fs.js:1099:18)
    at rimrafSync (C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:305:17)
    at C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:340:5
    at Array.forEach (native)
    at rmkidsSync (C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:339:26)
    at rmdirSync (C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:332:7)
    at rimrafSync (C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:303:9)
    at C:\projects\electron-mocha\node_modules\rimraf\rimraf.js:340:5
    at Array.forEach (native)
```

🔴 Failing spec on AppVeyor before change: https://ci.appveyor.com/project/kevinsawicki/electron-mocha/build/1.0.3

🍏 Passing spec on AppVeyor after change: https://ci.appveyor.com/project/kevinsawicki/electron-mocha/build/1.0.4

Closes #77 