### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test/
+.npmignore
+.travis.yml
+appveyor.yml


### PR DESCRIPTION
This pull request adds an initial `.npmignore` file ignores the test folder and CI build files from the packaged version.

Reduces the compressed size of `npm pack .` from from `9.8K` to `8.9K`.