### PR TITLE
Add a --require-main option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Usage: electron-mocha [options] [files]
     --recursive            include sub directories
     --renderer             run tests in renderer process
     --preload <name>       preload the given script in renderer process
+    --require-main <name>  load the given script in main process before executing tests
 
 ```
 

--- a/args.js
+++ b/args.js
@@ -33,6 +33,7 @@ function parse (argv) {
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
     .option('--preload <name>', 'preload the given script in renderer process', modules, [])
+    .option('--require-main <name>', 'load the given script in main process before executing tests', modules, [])
 
   module.paths.push(cwd, join(cwd, 'node_modules'))
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ app.on('quit', () => {
 app.on('window-all-closed', () => {})
 
 app.on('ready', () => {
+  if (opts.requireMain.length === 1) {
+    require(opts.requireMain[0])
+  }
   if (!opts.renderer) {
     mocha.run(opts, count => app.exit(count))
   } else {

--- a/test/main/opts_test.js
+++ b/test/main/opts_test.js
@@ -6,4 +6,8 @@ describe('mocha.opts', function () {
   it('--require modules are loaded', function () {
     assert.equal(true, global.required)
   })
+
+  it('--require-main modules are loaded', function () {
+    assert.equal(true, global.requiredMain)
+  })
 })

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --require test/support/require
 --preload test/support/preload.js
+--require-main test/support/requireMain

--- a/test/renderer/opts_test.js
+++ b/test/renderer/opts_test.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var remote = require('electron').remote
 
 /* global describe it */
 
@@ -9,5 +10,9 @@ describe('mocha.opts', function () {
 
   it('--preload scripts are loaded', function () {
     assert.equal(true, window.preloaded)
+  })
+
+  it('--require-main modules are loaded in the main process', function () {
+    assert.equal(true, remote.getGlobal('requiredMain'))
   })
 })

--- a/test/support/requireMain.js
+++ b/test/support/requireMain.js
@@ -1,0 +1,1 @@
+global.requiredMain = true


### PR DESCRIPTION
This will allow loading main process test utils when testing in the renderer process.  Mocking the `remote` module in electron is iffy at the best of times so if we can require modules in the main process to help us mock the actual main process implementation it will make testing things in the renderer a lot easier 👍 