### PR TITLE
Allow focus when debugging tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,11 +41,11 @@ app.on('ready', () => {
     var win = window.createWindow({
       height: 700,
       width: 1200,
-      focusable: false,
+      focusable: opts.debug,
       webPreferences: { webSecurity: false }
     })
 
-    if (process.platform === 'darwin') {
+    if (!opts.debug && process.platform === 'darwin') {
       app.dock.hide()
     }
 


### PR DESCRIPTION
Addresses #86. Also testing #75 (since I'm on a Mac), the only time my workspace is changed to the one with electron-mocha running is when the `--debug-brk` flag is present, thus I believe that issue is also resolved.