### PR TITLE
Add `--interactive` mode

### DIFF
--- a/args.js
+++ b/args.js
@@ -32,6 +32,7 @@ function parse (argv) {
     .option('--opts <path>', 'specify opts path', 'test/mocha.opts')
     .option('--recursive', 'include sub directories')
     .option('--renderer', 'run tests in renderer process')
+    .option('--interactive', 'run tests in renderer process in a visible window that can be reloaded to re-run tests')
     .option('--preload <name>', 'preload the given script in renderer process', modules, [])
     .option('--require-main <name>', 'load the given script in main process before executing tests', modules, [])
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,13 @@ app.on('ready', () => {
   if (opts.requireMain.length === 1) {
     require(opts.requireMain[0])
   }
+
+  if (opts.interactive) {
+    opts.renderer = true
+    opts.debug = true
+    opts.colors = false
+  }
+
   if (!opts.renderer) {
     mocha.run(opts, count => app.exit(count))
   } else {
@@ -70,7 +77,9 @@ app.on('ready', () => {
     // win.showURL(indexPath, opts)
     ipc.on('mocha-done', (event, count) => {
       win.webContents.once('destroyed', () => app.exit(count))
-      win.close()
+      if (!opts.interactive) {
+        win.close()
+      }
     })
     ipc.on('mocha-error', (event, data) => {
       writeError(data)

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -1,4 +1,9 @@
-require('./console')
+var opts = window.__args__
+
+if (!opts.interactive) {
+  require('./console')
+}
+
 var mocha = require('../mocha')
 var { ipcRenderer: ipc } = require('electron')
 
@@ -14,7 +19,6 @@ window.onerror = function (message, filename, lineno, colno, err) {
   })
 }
 
-var opts = window.__args__
 // console.log(JSON.stringify(opts, null, 2))
 
 opts.preload.forEach(function (script) {


### PR DESCRIPTION
This adds a new `--interactive` option which is similar to `--debug --renderer` but does not close the Electron window when tests finish running. Tests can be re-run by reloading the window and all output goes to the dev tools console rather than the terminal.

This streamlines the workflow when making heavy use of the dev tools during TDD sessions. Objects such as DOM nodes can be visualized in the console more easily than they can in the terminal, and the feedback loop is shorter when you only need to reload the window to re-run tests.

I have allowed edits from maintainers, so feel free to adjust this. Thanks! 🙇 