### PR TITLE
Remove uncaught exception errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,7 @@ var window = require('electron-window')
 var getOptions = require('mocha/bin/options')
 var args = require('./args')
 var mocha = require('./mocha')
-var util = require('util')
 var { app, ipcMain: ipc } = require('electron')
-
-process.on('uncaughtException', (err) => {
-  console.error(err)
-  console.error(err.stack)
-  app.exit(1)
-})
 
 // load mocha.opts into process.argv
 getOptions()
@@ -81,16 +74,5 @@ app.on('ready', () => {
         win.close()
       }
     })
-    ipc.on('mocha-error', (event, data) => {
-      writeError(data)
-      app.exit(1)
-    })
   }
 })
-
-function writeError (data) {
-  process.stderr.write(util.format('\nError encountered in %s: %s\n%s',
-    path.relative(process.cwd(), data.filename),
-    data.message,
-    data.stack))
-}

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -10,15 +10,6 @@ var { ipcRenderer: ipc } = require('electron')
 // Expose mocha
 window.mocha = require('mocha')
 
-window.onerror = function (message, filename, lineno, colno, err) {
-  ipc.send('mocha-error', {
-    message: message,
-    filename: filename,
-    err: err,
-    stack: err.stack
-  })
-}
-
 // console.log(JSON.stringify(opts, null, 2))
 
 opts.preload.forEach(function (script) {


### PR DESCRIPTION
Mocha registers exception handlers (work in main and renderer) to handle async test failures. If we handle uncaught exceptions (and exit) the test suite will not run to completion. See #93 

I think the best approach is actually for us to not handle uncaught errors at all since Mocha will handle them anyway. I have not had time to add tests for this (would be nice, but requires some effort, because it would have to be an integration test to be useful really). But I tested this with some of my own projects and made sure that if I throw errors in a test or hook they're picked up, so I hope this is good to merge. 