### PR TITLE
Trigger 'mocha-start' on page reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,9 @@ app.on('ready', () => {
       app.dock.hide()
     }
 
-    win.on('ready-to-show', () => {
+    var firstRun = true
+    win.once('ready-to-show', () => {
+      firstRun = false
       if (opts.debug) {
         win.show()
         win.webContents.openDevTools()
@@ -68,6 +70,12 @@ app.on('ready', () => {
           }, 250)
         })
       } else {
+        win.webContents.send('mocha-start')
+      }
+    })
+
+    ipc.on('mocha-ready-to-run', () => {
+      if (!firstRun) {
         win.webContents.send('mocha-start')
       }
     })

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -26,6 +26,8 @@ try {
   })
 }
 
+ipc.send('mocha-ready-to-run')
+
 ipc.on('mocha-start', () => {
   try {
     mocha.run(opts, function (failureCount) {


### PR DESCRIPTION
Otherwise tests only run once on the initial window open and nothing happens on page reload.

Fixes #96