### PR TITLE
Fix EPERM exception that can occur when cleaning up temporary files

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const opts = args.parse(process.argv)
 const tmpdir = fs.mkdtempSync(join(app.getPath('temp'), 'electron-mocha-'))
 app.setPath('userData', tmpdir)
 
-app.on('quit', () => {
+app.on('exit', () => {
   fs.removeSync(tmpdir)
 })
 


### PR DESCRIPTION
I get the following error when running tests for `electron-mocha` and when running tests with coverage for my own project.

```
{ Error: EPERM: operation not permitted, unlink 'C:\Users\MICROS~1\AppData\Local\Temp\electron-mocha-AW5lDG\GPUCache\data_0'
    at Object.fs.unlinkSync (fs.js:1091:18)
    at fixWinEPERMSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:169:13)
    at rimrafSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:260:26)
    at options.readdirSync.forEach.f (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:291:39)
    at Array.forEach (native)
    at rmkidsSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:291:26)
    at rmdirSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:283:7)
    at fixWinEPERMSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:167:5)
    at rimrafSync (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:260:26)
    at options.readdirSync.forEach.f (S:\Projects\_GitHub\electron-mocha\node_modules\fs-extra\lib\remove\rimraf.js:291:39)
  errno: -4048,
  code: 'EPERM',
  syscall: 'unlink',
  path: 'C:\\Users\\MICROS~1\\AppData\\Local\\Temp\\electron-mocha-AW5lDG\\GPUCache\\data_0' }
```

This causes `electron-mocha` to fail to clean up temporary files. Changing cleanup to happen on `exit` instead of `quit` fixes it. I'm not sure if there's any other implications from doing this.