### PR TITLE
Run clean up in a separate task

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,8 @@
+const fs = require('fs-extra')
+// Wait some amount of time to try to ensure that Electron has fully quit.
+setTimeout(removeTmpdir, 1000)
+
+function removeTmpdir () {
+  const tmpdir = process.argv[2]
+  fs.removeSync(tmpdir)
+}

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra')
-// Wait some amount of time to try to ensure that Electron has fully quit.
+// Wait some amount of time to try to ensure Electron has fully quit.
 setTimeout(removeTmpdir, 1000)
 
 function removeTmpdir () {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const getOptions = require('mocha/bin/options')
 const args = require('./args')
 const mocha = require('./mocha')
 const { app, ipcMain: ipc } = require('electron')
+const { spawn } = require('child_process')
 
 // load mocha.opts into process.argv
 getOptions()
@@ -18,7 +19,16 @@ const tmpdir = fs.mkdtempSync(join(app.getPath('temp'), 'electron-mocha-'))
 app.setPath('userData', tmpdir)
 
 app.on('quit', () => {
-  fs.removeSync(tmpdir)
+  const env = { 'ELECTRON_RUN_AS_NODE': 1 }
+  // Run cleanup in a separate process so that we're not trying to remove
+  // Electron's data out from under it.
+  const child = spawn(process.execPath, ['cleanup.js', tmpdir], {
+    detached: true,
+    stdio: 'ignore',
+    env,
+    cwd: __dirname
+  })
+  child.unref()
 })
 
 // do not quit if tests open and close windows

--- a/index.js
+++ b/index.js
@@ -19,13 +19,12 @@ const tmpdir = fs.mkdtempSync(join(app.getPath('temp'), 'electron-mocha-'))
 app.setPath('userData', tmpdir)
 
 app.on('quit', () => {
-  const env = { 'ELECTRON_RUN_AS_NODE': 1 }
   // Run cleanup in a separate process so that we're not trying to remove
   // Electron's data out from under it.
   const child = spawn(process.execPath, ['cleanup.js', tmpdir], {
     detached: true,
     stdio: 'ignore',
-    env,
+    env: { 'ELECTRON_RUN_AS_NODE': 1 },
     cwd: __dirname
   })
   child.unref()


### PR DESCRIPTION
This is addressing the same thing https://github.com/jprichardson/electron-mocha/pull/103 was trying to address. See also https://github.com/electron/electron/issues/9583, https://github.com/electron/electron/issues/8685 and https://github.com/jprichardson/electron-mocha/issues/98.

The root of the problem is that `electron-mocha` would try to delete Electron's `userData` directory out from under it while it was still running. That happened to work sometimes, but as those issues show, it's pretty fragile.

Instead, we could spawn a separate task to clean up after Electron's quit.