### PR TITLE
fix for electron-compile support

### DIFF
--- a/bin/electron-mocha
+++ b/bin/electron-mocha
@@ -6,8 +6,7 @@ var which = require('which')
 
 var electron = process.env.ELECTRON_PATH ||
   resolve('electron') || resolve('electron-prebuilt') ||
-  resolve('electron-compile') || resolve('electron-prebuilt-compile') ||
-  resolve('electron', which.sync)
+  resolve('electron-prebuilt-compile') || resolve('electron', which.sync)
 
 if (!electron) {
   console.error('')


### PR DESCRIPTION
Sorry guys! Turns out `electron-compile` doesn't actually use `electron` underneath, it just depends on `electron-prebuilt-compile`, so we can't `resolve('electron-compile')`. So #111 won't work if the user has `electron-compile` as a dependency.

Since `electron-compile` depends on its prebuilt counterpart, we can just `resolve` that and it will work in both cases (whether they have `electron-compile` or just `electron-prebuilt-compile`).