### PR TITLE
add --ignore-gpu-blacklist option

### DIFF
--- a/args.js
+++ b/args.js
@@ -34,6 +34,7 @@ function parse (argv) {
     .option('--renderer', 'run tests in renderer process')
     .option('--preload <name>', 'preload the given script in renderer process', modules, [])
     .option('--require-main <name>', 'load the given script in main process before executing tests', modules, [])
+    .option('--ignore-gpu-blacklist', 'run electron with --ignore-gpu-blacklist')
 
   module.paths.push(cwd, join(cwd, 'node_modules'))
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ const opts = args.parse(process.argv)
 const tmpdir = fs.mkdtempSync(join(app.getPath('temp'), 'electron-mocha-'))
 app.setPath('userData', tmpdir)
 
+if (opts.ignoreGpuBlacklist) {
+  app.commandLine.appendSwitch('ignore-gpu-blacklist')
+}
+
 // Load `--require-main` script first
 if (opts.requireMain.length === 1) {
   try {


### PR DESCRIPTION
Hi!

This pull request is asking to add a new option `--ignore-gpu-blacklist`.

Because when testing WebGL on CI services (travis/circleCI, etc), electron needs to run with this commandline argument (CI services usually don't have GPU support). Otherwise, webgl tests will fail due to errors when getting webgl context of canvas.

You can refer to [webgl-test-ci](https://github.com/socialtables/webgl-test-ci#enviroments)'s explanation about this.

Thanks!