### PR TITLE
Enable loading multiple --require-main scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,10 @@ const opts = args.parse(process.argv)
 const tmpdir = fs.mkdtempSync(join(app.getPath('temp'), 'electron-mocha-'))
 app.setPath('userData', tmpdir)
 
-// Load `--require-main` script first
-if (opts.requireMain.length === 1) {
+// Load `--require-main` scripts first
+for (let i = 0; i < opts.requireMain.length; i++) {
   try {
-    require(opts.requireMain[0])
+    require(opts.requireMain[i])
   } catch (error) {
     fail(error)
   }


### PR DESCRIPTION
This PR fixes the artificial constraint put on `--require-main` which previously would only load the given script if _only one_ `--require-main` argument is given. 

This behaviour is confusing because it would do nothing when providing two scripts via `--require-main` and misleading at best. In contrast, the `--require` argument allows for multiple scripts to be provided.

The rationale behind loading multiple scripts is to preload Babel or TypeScript transpilers to be able to run modern JavaScript as preload scripts. 

In my case, I use one script for the main electron process in order to turn off logging to file for the tested components (I use `electron-log`) and in the renderer process I do preload Chai extensions and configure Enzyme.


```
cross-env NODE_ENV=test electron-mocha --renderer 
--reporter spec 
--require ts-node/register 
--require "test/setup/renderer.ts"
--require-main ts-node/register 
--require-main "test/setup/main.ts" 
"test/*.spec.tsx"
```