### PR TITLE
fix travis CI configuration for Xenial build

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ running in a [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)) pr
 On Linux, your `.travis.yml` will need an extra line of configuration to run your tests:
 
 ```yaml
-before_script:
-  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 ```
 
 #### WebGL Tests


### PR DESCRIPTION
Adding:

    sh -e /etc/init.d/xvfb start

results in the following error:

    sh: 0: Can't open /etc/init.d/xvfb

see: https://benlimmer.com/2019/01/14/travis-ci-xvfb/