### PR TITLE
Make sure `win.close()` is only called once.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -154,9 +154,13 @@ exports.handler = argv => {
 
         win.webContents.on('destroyed', () => app.exit(code))
 
+        // Make sure `win.close()` is only called once.
+        // Otherwise electron throws "Object has been destroyed" error.
+        let mochaDone = false
         ipc.on('mocha-done', (event, count) => {
           code = Math.min(count, 255)
-          if (!(argv.interactive || argv.watch)) {
+          if (!(argv.interactive || argv.watch) && !mochaDone) {
+            mochaDone = true
             win.close()
           }
         })


### PR DESCRIPTION
Otherwise electron throws "Object has been destroyed" error.

Before:
![image](https://user-images.githubusercontent.com/23721/71753091-ba54cd00-2e81-11ea-82e4-0b15511643d6.png)

After:
![image](https://user-images.githubusercontent.com/23721/71753110-ce003380-2e81-11ea-8949-ee60edfed228.png)

