### PR TITLE
Respect the full-trace option to show stack traces on error

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -192,7 +192,9 @@ exports.handler = argv => {
           })
       }
     })
-    .catch(fail)
+    .catch((err) => {
+      fail(err, argv['full-trace'])
+    })
 }
 
 const fail = (error, trace) => {


### PR DESCRIPTION
Just spent a while tracking down an error in some wrapper code where the error had no stack track associated with it - to get the stack trace to show I had to make this change.