### PR TITLE
Explicitly exit from cleanup script

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -5,4 +5,6 @@ setTimeout(removeTmpdir, 1000)
 function removeTmpdir () {
   const tmpdir = process.argv[2]
   fs.removeSync(tmpdir)
+  // Electron builds with disabled ELECTRON_RUN_AS_NODE needs to explicitly exit.
+  process.exit(0)
 }


### PR DESCRIPTION
Hello, 
I have Electron builds with disabled "run as node" feature (for security reasons) and electron-mocha works just fine with that, but cleanup script process never exits because it's not running "as node" but as "as electron". As a result I have bunch of electron processes hanging around, here's how it looks for me 😄 :  
<img width="2560" alt="Screenshot 2020-05-07 at 16 52 51" src="https://user-images.githubusercontent.com/546887/81310381-4c652000-9084-11ea-9914-ccf4313bfb16.png">

Would you mind merging this small change which will fix my use-case? It's not breaking normal Electron in any way and it's in line with the current code, just explicitly exiting the app.

Thank you 🙇 