### PR TITLE
:feature: Allow custom index.html

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -74,12 +74,6 @@ exports.builder = yargs => {
         describe: 'Enable debugger on [port]',
         group: 'Electron',
         hidden: true
-      },
-      index: {
-        describe: 'Load custom index.html',
-        group: 'Electron',
-        hidden: false,
-        requiresArg: true
       }
     })
     .check(argv => {
@@ -122,9 +116,7 @@ exports.builder = yargs => {
         if (fs.existsSync(join(process.cwd(), argv.index))) {
           argv.index = join(process.cwd(), argv.index)
         } else {
-          throw errors.createMissingArgumentError(
-            '"--index" requires an existing path'
-          )
+          throw errors.createMissingArgumentError('"--index" requires an existing path')
         }
       }
       return true
@@ -165,7 +157,8 @@ exports.handler = async argv => {
           enableRemoteModule: true,
           contextIsolation: false,
           nodeIntegration: true,
-          webSecurity: false
+          webSecurity: false,
+          preload: join(__dirname, '..', 'renderer', 'run.js')
         }
       })
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -7,6 +7,7 @@ const { errors, helpers, ONE_AND_DONES } = require('./mocha')
 const run = require('mocha/lib/cli/run')
 const ansi = require('ansi-colors')
 const symbols = require('log-symbols')
+const fs = require('fs')
 
 const whenReady = app.isReady()
   ? Promise.resove()
@@ -73,6 +74,12 @@ exports.builder = yargs => {
         describe: 'Enable debugger on [port]',
         group: 'Electron',
         hidden: true
+      },
+      index: {
+        describe: 'Load custom index.html',
+        group: 'Electron',
+        hidden: false,
+        requiresArg: true
       }
     })
     .check(argv => {
@@ -111,7 +118,15 @@ exports.builder = yargs => {
       if (argv.script) {
         argv.script = argv.script.map(script => resolve(script))
       }
-
+      if(argv.index){
+          if(fs.existsSync(join(process.cwd(), argv.index))){
+              argv.index = join(process.cwd(), argv.index)
+          }else{
+              throw errors.createMissingArgumentError(
+                  '"--index" requires an existing path'
+              )
+          }
+      }
       return true
     })
 }
@@ -171,7 +186,7 @@ exports.handler = async argv => {
 
       // Undocumented call in electron-window
       win._loadURLWithArgs(
-        join(__dirname, '../renderer/index.html'),
+        argv.index ? argv.index : join(__dirname, '../renderer/index.html'),
         argv,
         () => {
           if (argv.inspect) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -118,14 +118,14 @@ exports.builder = yargs => {
       if (argv.script) {
         argv.script = argv.script.map(script => resolve(script))
       }
-      if(argv.index){
-          if(fs.existsSync(join(process.cwd(), argv.index))){
-              argv.index = join(process.cwd(), argv.index)
-          }else{
-              throw errors.createMissingArgumentError(
-                  '"--index" requires an existing path'
-              )
-          }
+      if (argv.index) {
+        if (fs.existsSync(join(process.cwd(), argv.index))) {
+          argv.index = join(process.cwd(), argv.index)
+        } else {
+          throw errors.createMissingArgumentError(
+            '"--index" requires an existing path'
+          )
+        }
       }
       return true
     })

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<script>require('./run')</script>
 </head>
 <body>
 <!--

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -1,3 +1,5 @@
+require('electron-window').parseArgs()
+
 const { ipcRenderer: ipc } = require('electron')
 const opts = window.__args__
 
@@ -25,14 +27,14 @@ try {
           message: `script not found: ${script}`
         })
       }
-      document.head.appendChild(tag)
+      document.body.appendChild(tag)
     }
   }
 
   // Expose Mocha for browser tests
   window.mocha = Mocha
 
-  handleScripts(opts.script)
+  window.addEventListener('load', () => handleScripts(opts.script))
 
   ipc.on('mocha-start', () => {
     try {


### PR DESCRIPTION
## Motivation
Bundlers export automatically-generated index.html which links to the compiled JavaScript code, CSS, etc... 

By not having the option to load a custom index.html you need to create a script and load with (`--script or --preload`) and create the `<script/>` s and  `<link/>`s in live, which is so painful.

 Although this would eventually work, then comes another problem. The images cannot load because the index.html is in another place so the relative paths break.

Also, https://github.com/jprichardson/electron-mocha/issues/117

## Fix
Add a argument to the cli (`--index`, that was my choice) which allows you to load your custom index.html.

This can be handy with automatically-generated `index.html` by bundlers.


