### PR TITLE
Corrected --preload behavior

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -76,6 +76,13 @@ exports.builder = yargs => {
         implies: 'renderer',
         type: 'string',
         requiresArg: true
+      },
+      preload: {
+        describe: 'Preload script',
+        group: 'Electron',
+        implies: 'renderer',
+        type: 'string',
+        requiresArg: true
       }
     })
     .check(argv => {

--- a/lib/run.js
+++ b/lib/run.js
@@ -123,7 +123,7 @@ exports.builder = yargs => {
       }
       if (argv.preload) {
         try {
-          argv.preload = join(process.cwd(), argv.preload)
+          argv.preload = resolve(argv.preload)
         } catch (e) {
           throw errors.createMissingArgumentError(
             `--preload requires file path [${e.code}].`

--- a/lib/run.js
+++ b/lib/run.js
@@ -52,7 +52,6 @@ exports.builder = yargs => {
         requiresArg: true
       },
       script: {
-        alias: 'preload',
         describe: 'Load module in renderer via script tag',
         group: 'Electron',
         implies: 'renderer',
@@ -115,7 +114,15 @@ exports.builder = yargs => {
       if (argv.script) {
         argv.script = argv.script.map(script => resolve(script))
       }
-
+      if (argv.preload) {
+        try {
+          argv.preload = join(process.cwd(), argv.preload)
+        } catch (e) {
+          throw errors.createMissingArgumentError(
+            `--preload requires file path [${e.code}].`
+          )
+        }
+      }
       return true
     })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mocha",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Mocha tests in Electron.",
   "main": "lib/main.js",
   "scripts": {

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -3,6 +3,10 @@ require('electron-window').parseArgs()
 const { ipcRenderer: ipc } = require('electron')
 const opts = window.__args__
 
+if(opts.preload){
+	require(opts.preload)
+}
+
 if (!opts.interactive) {
   require('./console')
 }

--- a/renderer/run.js
+++ b/renderer/run.js
@@ -3,8 +3,8 @@ require('electron-window').parseArgs()
 const { ipcRenderer: ipc } = require('electron')
 const opts = window.__args__
 
-if(opts.preload){
-	require(opts.preload)
+if (opts.preload) {
+  require(opts.preload)
 }
 
 if (!opts.interactive) {


### PR DESCRIPTION
## Description
`--script` ( alias `--preload`) injects a script tag, which is ok. But, --preload should have a totally different behavior, it should be loaded before the website even loads, not as a script.

## Solution
Make `--preload` a standalone option instead of an alias of `--script` and be runned as a preload script like ElectronJS  Docs say.

👍🏻 