### PR TITLE
refactor: do not use "remote" module for console calls

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -7,6 +7,7 @@ const { errors, helpers, ONE_AND_DONES } = require('./mocha')
 const run = require('mocha/lib/cli/run')
 const ansi = require('ansi-colors')
 const symbols = require('log-symbols')
+const util = require('util')
 
 exports.command = run.command
 exports.describe = 'Run tests with Electron-Mocha'
@@ -188,6 +189,8 @@ exports.handler = async argv => {
       })
       ipc.on('mocha-warn', (_, warning) => warn(warning))
 
+      ipc.on('console-call', print)
+
       // Undocumented call in electron-window
       win._loadURLWithArgs(
         argv.url ? argv.url : join(__dirname, '../renderer/index.html'),
@@ -225,4 +228,9 @@ const fail = (error, trace) => {
 
 const warn = warning => {
   console.warn(ansi.yellow(`Warning: ${warning.message}`))
+}
+
+const print = (_, method, args) => {
+  const output = util.format.apply(null, args)
+  console[method](output)
 }

--- a/renderer/console.js
+++ b/renderer/console.js
@@ -1,10 +1,13 @@
-const { remote } = require('electron')
-const remoteConsole = remote.require('console')
+const { ipcRenderer: ipc } = require('electron')
 
-console.log = (...args) => {
-  remoteConsole.log(...args)
-}
+const { hasOwnProperty } = Object.prototype
 
-console.dir = (...args) => {
-  remoteConsole.dir(...args)
+const fakeConsole = {}
+for (const k in console) {
+  if (hasOwnProperty.call(console, k) && k !== 'assert') {
+    fakeConsole[k] = (...args) => ipc.send('console-call', k, args)
+  }
 }
+global.__defineGetter__('console', function () {
+  return fakeConsole
+})


### PR DESCRIPTION
Electron allows disabling "remote" module at build time.
Let's make "electron-mocha" work for such builds.

Avoid using "remote" module and use IPC calls
for console logging in non-interactive renderers.

Based on what Electron itself does for its tests
https://github.com/electron/electron/blob/22cb3cd18b1b771364edada515a4c138a8dddc6d/spec/static/main.js#L55-L63
https://github.com/electron/electron/blob/22cb3cd18b1b771364edada515a4c138a8dddc6d/spec/static/index.html#L18-L27