### PR TITLE
ci: allow builds targeting Electron "beta" to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ install:
   - $(npm bin)/electron --version
 script:
   - if [[ $ELECTRON_VERSION = "beta" ]]; then
-      npm test;
-    else
       npm test || true;
+    else
+      npm test;
     fi
 notifications:
   email: false


### PR DESCRIPTION
The logic seems to be inverted now.