### PR TITLE
ci: add Electron 10 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - node_js: stable
       os: osx
     - node_js: 12
+      env: ELECTRON_VERSION=10
+    - node_js: 12
       env: ELECTRON_VERSION=9
     - node_js: 12
       env: ELECTRON_VERSION=8


### PR DESCRIPTION
It was released in August.
https://www.electronjs.org/blog/electron-10-0