### PR TITLE
Fix uncaught promise rejection

### DIFF
--- a/renderer/run.js
+++ b/renderer/run.js
@@ -40,9 +40,9 @@ try {
 
   window.addEventListener('load', () => handleScripts(opts.script))
 
-  ipc.on('mocha-start', () => {
+  ipc.on('mocha-start', async () => {
     try {
-      helpers.runMocha({ ...opts }, (...args) => {
+      await helpers.runMocha({ ...opts }, (...args) => {
         ipc.send('mocha-done', ...args)
       })
     } catch (e) {


### PR DESCRIPTION
This lead to electron-mocha hanging in `--interactive` in case there was an exception in preload (e.g. ts-node/register).