### PR TITLE
Set `focusable: true` when `--renderer`

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -171,7 +171,7 @@ exports.handler = async argv => {
       const win = createWindow({
         height: 700,
         width: 1200,
-        focusable: argv.inspect,
+        focusable: argv.renderer,
         webPreferences: {
           enableRemoteModule: true,
           contextIsolation: false,


### PR DESCRIPTION
Otherwise browser doesn't capture `blur`/`focus` events and thus behaves slightly different (and unexpectedly so) from the regular browser. This breaks certain functionalities that rely on those events (e.g. emulating a user filling in input and then moving on to click a button - involves firing `blur` after setting the input).

More discussion here #171