### PR TITLE
Add `window-config-file` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ with these additional options:
     --interactive           Show renderer tests in persistent window   [boolean]
     --url, --index          Load custom URL in renderer                [string]
     --preload               Load module during renderer preload        [string]
+    --window-config-file    Supply custom electron window options      [string]
     -W, --warnings          Print renderer warnings to console         [boolean]
+
+`window-config-file` must be a javascript file that exports an options object. Check out [electron docs](https://www.electronjs.org/docs/api/browser-window#new-browserwindowoptions) for the list of available options.
 
 For the full list of available options, see `electron-mocha --help`.
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,6 +91,11 @@ exports.builder = yargs => {
         describe: 'Print renderer warnings to console',
         group: 'Electron',
         type: 'boolean'
+      },
+      'window-config-file': {
+        describe: 'Supply custom electron window options',
+        group: 'Electron',
+        implies: 'renderer'
       }
     })
     .check(argv => {
@@ -142,6 +147,30 @@ exports.builder = yargs => {
     })
 }
 
+function windowOptions (argv) {
+  const customWindowOptions = argv['window-config-file'] ? require(join(process.cwd(), argv['window-config-file'])) : {}
+  const windowOptions = mergeDeep(
+    {
+      height: 700,
+      width: 1200,
+      focusable: argv.renderer || argv.inspect,
+      webPreferences: {
+        enableRemoteModule: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        webSecurity: false
+      }
+    },
+    customWindowOptions,
+    {
+      webPreferences: {
+        preload: join(__dirname, '..', 'renderer', 'run.js')
+      }
+    }
+  )
+  return windowOptions
+}
+
 exports.handler = async argv => {
   try {
     await helpers.handleRequires(argv['require-main'])
@@ -168,18 +197,7 @@ exports.handler = async argv => {
         }
       })
     } else {
-      const win = createWindow({
-        height: 700,
-        width: 1200,
-        focusable: argv.inspect,
-        webPreferences: {
-          enableRemoteModule: true,
-          contextIsolation: false,
-          nodeIntegration: true,
-          webSecurity: false,
-          preload: join(__dirname, '..', 'renderer', 'run.js')
-        }
-      })
+      const win = createWindow(windowOptions(argv))
 
       win.webContents.on('destroyed', () => app.exit(code))
 
@@ -244,4 +262,27 @@ const warn = warning => {
 const print = (method, args) => {
   const output = util.format.apply(null, args)
   console[method](output)
+}
+
+function isObject (item) {
+  return (item && typeof item === 'object' && !Array.isArray(item))
+}
+
+// Copied from https://stackoverflow.com/a/34749873/51209
+function mergeDeep (target, ...sources) {
+  if (!sources.length) return target
+  const source = sources.shift()
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} })
+        mergeDeep(target[key], source[key])
+      } else {
+        Object.assign(target, { [key]: source[key] })
+      }
+    }
+  }
+
+  return mergeDeep(target, ...sources)
 }


### PR DESCRIPTION
Allow custom electron window options. See #171 for motivation.

Also changes `focusable` default to `true` on renderer (fixes #171).