### PR TITLE
Fix broken import

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -9,7 +9,7 @@ const {
 } = require('mocha/lib/cli/run-helpers')
 
 const collectFiles = require('mocha/lib/cli/collect-files')
-const watchRun = require('mocha/lib/cli/watch-run')
+const { watchRun } = require('mocha/lib/cli/watch-run')
 
 const {
   ONE_AND_DONES


### PR DESCRIPTION
```
✖ ERROR: watchRun is not a function
TypeError: watchRun is not a function
    at Object.runMocha (/home/artem/projects/browser-monkey/node_modules/electron-mocha/lib/mocha.js:31:11)
```

Note: I wasn't able to see it actually rerunning tests on file changes, even after fixing the code.