### PR TITLE
feat: support esm tests

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -31,6 +31,7 @@ const runMocha = async (argv, done) => {
     await watchRun(mocha, { ui: argv.ui }, argv)
   } else {
     mocha.files = collectFiles(argv)
+    await mocha.loadFilesAsync()
     await mocha.run(done)
   }
 }

--- a/test/main/esm-tests.mjs
+++ b/test/main/esm-tests.mjs
@@ -1,0 +1,7 @@
+import assert from 'assert'
+
+describe('esm test', () => {
+  it('runs an esm test', () => {
+    assert.strictEqual(true, true)
+  })
+})

--- a/test/renderer/esm-tests.mjs
+++ b/test/renderer/esm-tests.mjs
@@ -1,0 +1,7 @@
+import assert from 'assert'
+
+describe('esm test', () => {
+  it('runs an esm test', () => {
+    assert.strictEqual(true, true)
+  })
+})


### PR DESCRIPTION
Mocha supports running esm tests if the node it's running on does, you just have to use the [loadFilesAsync()](https://mochajs.org/api/mocha#loadFilesAsync) method.

This seems to work fine in the electron main process but in the renderer it hangs on [this line](https://github.com/mochajs/mocha/blob/master/lib/nodejs/esm-utils.js#L7) when it tries to load any file, esm or cjs.

I don't know electron or mocha well enough to diagnose the issue, anyone got any ideas?

Upgrading mocha and/or electron didn't help.