### PR TITLE
Print error in console when mocha failed in interactive mode

### DIFF
--- a/renderer/run.js
+++ b/renderer/run.js
@@ -46,7 +46,11 @@ try {
         ipc.send('mocha-done', ...args)
       })
     } catch (e) {
-      fail(e)
+      if (opts.interactive) {
+        console.error(e)
+      } else {
+        fail(e)
+      }
     }
   })
 


### PR DESCRIPTION
When mocha failed, electron will be forced to exit and print error in command line.

It's not convienient when error thrown by imported scripts, so I change to print error stack in console in interactive mode

e.g:
```js
// error in myFoo will shut down electron
const foo = require('myFoo');

describe('bar', () => {
  it('case', () => {});
});
```