### PR TITLE
Support ES modules in main process testing

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -52,6 +52,10 @@ const runMocha = async (argv, done) => {
     await watchRun(mocha, { ui: argv.ui }, argv)
   } else {
     mocha.files = collectFiles(argv)
+    // In the main process we can handle ESM, but not the renderer
+    if (process.type !== 'renderer') {
+      await mocha.loadFilesAsync()
+    }
     await mocha.run(done)
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "standard",
     "test": "npm run test:main && npm run test:renderer",
-    "test:main": "node bin/electron-mocha test/main",
+    "test:main": "node bin/electron-mocha --require test/support/requireES.mjs test/main",
     "test:renderer": "node bin/electron-mocha --config .mocharc.renderer.json test/renderer",
     "mocha": "node bin/electron-mocha",
     "prepublishOnly": "npm test"

--- a/test/main/esm_test.mjs
+++ b/test/main/esm_test.mjs
@@ -1,0 +1,9 @@
+'use strict'
+
+import assert from 'assert'
+
+describe('electron-mocha ESM', () => {
+  it('tests in ES modules run', () => {
+    assert.ok(true)
+  })
+})

--- a/test/main/opts_test.js
+++ b/test/main/opts_test.js
@@ -7,6 +7,10 @@ describe('mocha.opts', () => {
     assert.strictEqual(true, global.required)
   })
 
+  it('--require ES modules are loaded', () => {
+    assert.strictEqual(true, global.requiredES)
+  })
+
   it('--require-main modules are loaded', () => {
     assert.strictEqual(true, global.requiredMain)
   })

--- a/test/support/requireES.mjs
+++ b/test/support/requireES.mjs
@@ -1,0 +1,1 @@
+global.requiredES = true


### PR DESCRIPTION
Use mocha's `loadFilesAsync()` to allow `--require` files and test files themselves to be ES modules.

We can't support `--require-main` files being ES modules because the loading is async, so we can't guarantee that they'll run before the app is ready.