### PR TITLE
add single-run option

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -204,7 +204,7 @@ exports.handler = async argv => {
 
       ipc.on('mocha-done', (event, count) => {
         code = Math.min(count, 255)
-        if (!(argv.interactive && !argv['single-run'] || argv.watch)) {
+        if (!((argv.interactive && !argv['single-run']) || argv.watch)) {
           if (!win.isDestroyed()) win.close()
         }
       })

--- a/lib/run.js
+++ b/lib/run.js
@@ -66,7 +66,7 @@ exports.builder = yargs => {
       'single-run': {
         describe: 'Exit with mocha-done event',
         group: 'Electron',
-        implies: 'renderer'
+        implies: 'interactive'
       },
       inspect: {
         alias: ['inspect-brk', 'inspect-port', 'debug'],

--- a/lib/run.js
+++ b/lib/run.js
@@ -63,6 +63,11 @@ exports.builder = yargs => {
         group: 'Electron',
         implies: 'renderer'
       },
+      'single-run': {
+        describe: 'Exit with mocha-done event',
+        group: 'Electron',
+        implies: 'renderer'
+      },
       inspect: {
         alias: ['inspect-brk', 'inspect-port', 'debug'],
         defaultDescription: '5858',
@@ -199,7 +204,7 @@ exports.handler = async argv => {
 
       ipc.on('mocha-done', (event, count) => {
         code = Math.min(count, 255)
-        if (!(argv.interactive || argv.watch)) {
+        if (!(argv.interactive && !argv['single-run'] || argv.watch)) {
           if (!win.isDestroyed()) win.close()
         }
       })


### PR DESCRIPTION
In some test context, tests will fail without `--interactive` option. In this case, `interactive` has to be enabled even in a single run test.

Add a new option `--single-run` to allow electron-mocha exit with mocha-done event in interactive mode.

